### PR TITLE
SC-5473 - adds env vars for edu-sharing lern-store

### DIFF
--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -50,7 +50,15 @@ services:
       # BRUTE FORCE PROTECTION
       - LOGIN_BLOCK_TIME=3
       # FEATURE TOGGLES
-      - LERNSTORE_MODE=LEGACY
+      - LERNSTORE_MODE=EDUSHARING
+      - ES_DOMAIN=
+      - ES_USER=
+      - ES_PASSWORD=
+      - ES_GRANT_TYPE=
+      - ES_OAUTH_SECRET=
+      - ES_CLIENT_ID=
+      - ES_MERLIN_USERNAME=
+      - ES_MERLIN_PW=
     ports:
       - "3030:3030"
       - "5959:5959"
@@ -88,7 +96,7 @@ services:
       # FEATURE TOGGLES
       - FEATURE_TEAMS_ENABLED=true
       - FEATURE_EXTENSIONS_ENABLED=true
-      - LERNSTORE_MODE=LEGACY
+      - LERNSTORE_MODE=EDUSHARING
       # - ROCKETCHAT_SERVICE_ENABLED=true
       # - EDTR_SOURCE=https://cdn.jsdelivr.net/gh/schul-cloud/edtrio@e9d3bb9d66092bafa07846269c8fc6f9d5fb0559/dist/index.js
       # BRUTE FORCE PROTECTION
@@ -114,7 +122,7 @@ services:
       - API_URL=http://server:3030
       # FEATURE TOGGLES
       - FEATURE_TEAMS_ENABLED=true
-      - LERNSTORE_MODE=LEGACY
+      - LERNSTORE_MODE=EDUSHARING
       # Theme and Titles
       - SC_THEME=default
     ports:
@@ -167,7 +175,7 @@ services:
       - redis
       - mail
     command: sh -c "npm run build & npm run start"
-      
+
 
 
   redis:

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -51,14 +51,14 @@ services:
       - LOGIN_BLOCK_TIME=3
       # FEATURE TOGGLES
       - LERNSTORE_MODE=EDUSHARING
-      - ES_DOMAIN=
-      - ES_USER=
-      - ES_PASSWORD=
-      - ES_GRANT_TYPE=
-      - ES_OAUTH_SECRET=
-      - ES_CLIENT_ID=
-      - ES_MERLIN_USERNAME=
-      - ES_MERLIN_PW=
+      - ES_DOMAIN=https://mv-repo.schul-cloud.org
+      - ES_USER
+      - ES_PASSWORD
+      - ES_GRANT_TYPE=password
+      - ES_OAUTH_SECRET
+      - ES_CLIENT_ID=eduApp
+      - ES_MERLIN_USERNAME
+      - ES_MERLIN_PW
     ports:
       - "3030:3030"
       - "5959:5959"


### PR DESCRIPTION
# Description

## Links to Tickets or other pull requests
- https://ticketsystem.schul-cloud.org/browse/SC-5473
- https://github.com/hpi-schul-cloud/integration-tests/pull/176

## Changes

Sets edu-sharing lernstore mode and adds placeholders for secrets.
These vars get replaced with env vars pulled from travis / github actions when the integration test run.
See [commit](https://github.com/hpi-schul-cloud/integration-tests/pull/176/commits/b1f48a4f30c2e130ebb04c1552d4bc3cea30de29) on integration_tests for details how this is done.

## Deployment

The vars needs to be set on each project where integration tests run in Travis / Github Actions.

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->


## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
