### PR TITLE
read envs from commandline

### DIFF
--- a/compose-files/docker-compose.yml
+++ b/compose-files/docker-compose.yml
@@ -66,10 +66,10 @@ services:
       - LOGIN_BLOCK_TIME=3
       # Edu-Sharing
       - ES_DOMAIN=https://mv-repo.schul-cloud.org
-      - ES_USER
-      - ES_PASSWORD
-      - SECRET_ES_MERLIN_USERNAME
-      - SECRET_ES_MERLIN_PW
+      - ES_USER={ES_USER}
+      - ES_PASSWORD={ES_PASSWORD}
+      - SECRET_ES_MERLIN_USERNAME={SECRET_ES_MERLIN_USERNAME}
+      - SECRET_ES_MERLIN_PW={SECRET_ES_MERLIN_PW}
       # FEATURE TOGGLES
       - LERNSTORE_MODE=EDUSHARING
     ports:
@@ -132,10 +132,23 @@ services:
       - HOST=0.0.0.0
       - API_URL=http://server:3030
       # FEATURE TOGGLES
+      - FEATURE_EXTENSIONS_ENABLED=true
+      - FEATURE_LERNSTORE_ENABLED=true
+      - FEATURE_MATRIX_MESSENGER_ENABLED=true
       - FEATURE_TEAMS_ENABLED=true
       - LERNSTORE_MODE=EDUSHARING
+      - SC_THEME=n21
+      - MATRIX_MESSENGER__DISCOVER_URI=https://staging.messenger.schule
+      - MATRIX_MESSENGER__EMBED_URI=https://embed.staging.messenger.schule
+      - MATRIX_MESSENGER__SCHOOL_ROOM_ENABLED=false
+      - MATRIX_MESSENGER__SCHOOL_SETTINGS_VISIBLE=true
+      - MATRIX_MESSENGER__STUDENT_ROOM_CREATION=false
+      - MATRIX_MESSENGER__URI=https://matrix.staging.messenger.schule
       # Theme and Titles
       - SC_THEME=default
+      - SECURITY_HEADERS_ENABLED=true
+      - SENTRY_DSN=https://6254905471a54f6196b11b7db7aec193@sentry.hpi-schul-cloud.org/4
+      - SENTRY_SAMPLE_RATE=1.0
     ports:
       - "4000:4000"
     restart: unless-stopped

--- a/compose-files/docker-compose.yml
+++ b/compose-files/docker-compose.yml
@@ -168,23 +168,10 @@ services:
       - HOST=0.0.0.0
       - API_URL=http://server:3030
       # FEATURE TOGGLES
-      - FEATURE_EXTENSIONS_ENABLED=true
-      - FEATURE_LERNSTORE_ENABLED=true
-      - FEATURE_MATRIX_MESSENGER_ENABLED=true
       - FEATURE_TEAMS_ENABLED=true
       - LERNSTORE_MODE=EDUSHARING
-      - SC_THEME=n21
-      - MATRIX_MESSENGER__DISCOVER_URI=https://staging.messenger.schule
-      - MATRIX_MESSENGER__EMBED_URI=https://embed.staging.messenger.schule
-      - MATRIX_MESSENGER__SCHOOL_ROOM_ENABLED=false
-      - MATRIX_MESSENGER__SCHOOL_SETTINGS_VISIBLE=true
-      - MATRIX_MESSENGER__STUDENT_ROOM_CREATION=false
-      - MATRIX_MESSENGER__URI=https://matrix.staging.messenger.schule
       # Theme and Titles
       - SC_THEME=default
-      - SECURITY_HEADERS_ENABLED=true
-      - SENTRY_DSN=https://6254905471a54f6196b11b7db7aec193@sentry.hpi-schul-cloud.org/4
-      - SENTRY_SAMPLE_RATE=1.0
     ports:
       - "4000:4000"
     restart: unless-stopped


### PR DESCRIPTION
# Description

directly add envs to docker-compose files instead of replacing string, makes it usable without e2e scripts


# Links
https://github.com/hpi-schul-cloud/end-to-end-tests/pull/282

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
