### PR TITLE
add missing encryption key sample for testing

### DIFF
--- a/docker-compose.end-to-end-tests-Build.yml
+++ b/docker-compose.end-to-end-tests-Build.yml
@@ -46,6 +46,7 @@ services:
       ## keys for local s3 storage
       # - AWS_ACCESS_KEY=
       # - AWS_SECRET_ACCESS_KEY=
+      - S3_KEY=<test-encryption-key>
       # URIs and Port
       - MONGO_URI=mongodb://server-mongodb:27017/schulcloud
       - DB_URL=mongodb://server-mongodb:27017/schulcloud


### PR DESCRIPTION
This PR enables client's unit tests to be able to start the server again which currently fails due to S3_KEY is missing in the docker file env.

See the related client PR where the tests are running successfully (while they fail on main): https://github.com/hpi-schul-cloud/schulcloud-client/pull/2693

Failing check on master: https://github.com/hpi-schul-cloud/schulcloud-client/runs/3995228585?check_suite_focus=true where the server not coming up.