### PR TITLE
Brb 38 h5p renderer

### DIFF
--- a/compose-files/docker-compose.yml
+++ b/compose-files/docker-compose.yml
@@ -289,7 +289,7 @@ services:
       - LEGACY_CLIENT_URL=http://client:3100
       - HOST=0.0.0.0
       - API_URL=${API_URL:-http://server:3030/api}
-      - H5P_FRAME_SRC_URLS="https://www.website.com"
+      - H5P_FRAME_SRC_URLS=https://www.website.com
       # FEATURE TOGGLES
       - FEATURE_TEAMS_ENABLED=true
       - LERNSTORE_MODE=EDUSHARING

--- a/compose-files/docker-compose.yml
+++ b/compose-files/docker-compose.yml
@@ -289,6 +289,7 @@ services:
       - LEGACY_CLIENT_URL=http://client:3100
       - HOST=0.0.0.0
       - API_URL=${API_URL:-http://server:3030/api}
+      - H5P_FRAME_SRC_URLS="https://www.website.com"
       # FEATURE TOGGLES
       - FEATURE_TEAMS_ENABLED=true
       - LERNSTORE_MODE=EDUSHARING


### PR DESCRIPTION
# Description
In order to display the H5P content for thuringia, we have to use the rendering service of Edu-Sharing. The renderer with content is displayed in an Iframe. Therefor, we fetch the rendering service from Edu-Sharing and load it into the Iframe.
Do not merge before [BC-2945](https://ticketsystem.dbildungscloud.de/browse/BC-2945)-es-kubernetes is merged into main!

## Links to Tickets or other pull requests

Epic with related tickets: https://ticketsystem.dbildungscloud.de/browse/BRB-38
Initiative: https://docs.dbildungscloud.de/pages/viewpage.action?pageId=190776231#expand-Abgrenzung
Documentation: https://docs.dbildungscloud.de/display/DBH/H5P
PR dof_app_deploy: https://github.com/hpi-schul-cloud/dof_app_deploy/pull/484
PR nuxt-client: https://github.com/hpi-schul-cloud/nuxt-client/pull/2437
PR sculcloud-server: https://github.com/hpi-schul-cloud/schulcloud-server/pull/3985

## Changes
I add the env var H5P_FRAME_SRC_URLS for the E2E tests.

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [X] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
